### PR TITLE
build: remove default `RPC_HTTP_HOST`

### DIFF
--- a/.env-copy
+++ b/.env-copy
@@ -1,5 +1,8 @@
-RPC_HTTP_HOST=https://node.rugpullindex.com
-RPC_API_KEY=abc
+# Replace with your node's URL
+# Consider running your own node or choosing an existing service from https://ethereumnodes.com/
+RPC_HTTP_HOST=
+
+RPC_API_KEY=
 DATA_DIR=data
 EXTRACTION_WORKER_CONCURRENCY=12
 IPFS_HTTPS_GATEWAY=https://cloudflare-ipfs.com/ipfs/

--- a/readme.md
+++ b/readme.md
@@ -12,10 +12,17 @@ Consider running your own node or choose an existing service from
 [ethereumnodes.com](https://ethereumnodes.com/).
 
 ```bash
+# Clone the repository
 git clone git@github.com:neume-network/core.git
+
+# Copy the example .env file
+# ⚠️ Be sure to update the variables in `.env` with the appropriate values!
 cp .env-copy .env
-# and replace `RPC_HTTP_HOST` with your node's URL
+
+# Install the dependnecies
 npm i
+
+# Run the service
 npm run dev
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ git clone git@github.com:neume-network/core.git
 # ⚠️ Be sure to update the variables in `.env` with the appropriate values!
 cp .env-copy .env
 
-# Install the dependnecies
+# Install the dependencies
 npm i
 
 # Run the service


### PR DESCRIPTION
## Summary

Closes https://github.com/neume-network/core/issues/60

This changes two parts of the example `.env-copy` file:

- it removes the default `RPC_HTTP_HOST`
- it adds a note for what value should be set to run the app

As a result, on a fresh clone, if the developer runs this app as-is,
it will throw an error notifying the developer that it's not set.

This "nudges" developers to replace this (and all relevant values)
to their preference.

### For review

👋  @TimDaub - Hi! Thanks for letting me contribute. This is a first pass of what I had in mind to incrementally improve my own developer experience. I'm happy to hear any changes I should make before getting this merged in. Thanks again for all of your help!