### PR TITLE
add test to check worker creation in boot.mjs

### DIFF
--- a/src/boot.mjs
+++ b/src/boot.mjs
@@ -11,7 +11,7 @@ import * as disc from "./disc.mjs";
 
 const workerPath = resolve(__dirname, "./worker_start.mjs");
 
-async function boot() {
+export async function createWorker() {
   environment.validate(environment.requiredVars);
   await disc.provisionDir(resolve(__dirname, "..", env.DATA_DIR));
 
@@ -26,9 +26,15 @@ async function boot() {
     workerData,
   });
 
+  return worker;
+}
+
+async function boot(worker) {
   await strategies.run(worker);
 }
 
-boot()
-  .catch((err) => console.error(err))
-  .then();
+if (env.NODE_ENV !== "test") {
+  createWorker()
+    .then(boot)
+    .catch((err) => console.error("******", err));
+}

--- a/test/boot_test.mjs
+++ b/test/boot_test.mjs
@@ -1,0 +1,19 @@
+import test from "ava";
+import { createWorker } from "../src/boot.mjs";
+
+test("should be able to create worker", (t) => {
+  return new Promise((resolve, reject) => {
+    createWorker().then((w) => {
+      setTimeout(() => {
+        // no error has occured until now, safe to pass the test
+        t.pass();
+        resolve();
+      }, 1000);
+
+      w.on("error", (error) => {
+        t.fail(error.toString());
+        reject();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Partially _fix_ #65

This PR adds a test for `boot.mjs` to check creation of worker. In situations when worker data is incorrect the test will fail. 

I couldn't add a test for `worker_start.mjs`. The main reason is that `isMainThread` is false due to ava executing the tests in a worker thread.

https://github.com/neume-network/core/blob/472f9ef9c4ccc9555496fa8bc1f2cccf38d9df60/src/worker_start.mjs#L20-L25