### PR TITLE
force close the app when an error bubbles up

### DIFF
--- a/neume.mjs
+++ b/neume.mjs
@@ -22,6 +22,10 @@ const argv = yargs(hideBin(process.argv))
   try {
     await boot(crawlPath, config);
   } catch (err) {
-    console.error(err.toString());
+    console.error(
+      "An unhandled error has bubbled up which shouldn't have happened. Force closing the application."
+    );
+    console.error(err);
+    process.exit();
   }
 })();


### PR DESCRIPTION
If the control flow reaches [here](https://github.com/neume-network/core/blob/6a64bc24077dbb14bf114e57ea76ab0d1a7a5777/neume.mjs#L25) then there isn't anything else to execute. But the process won't exit because worker is still running. So, we force close using process.exit().