### PR TITLE
re: add unhandledRejections flag to node

### DIFF
--- a/neume.mjs
+++ b/neume.mjs
@@ -1,4 +1,8 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --unhandled-rejections=throw
+
+// Note: The -S flag for env is available for FreeBSD and coreutils >= 8.30
+// It should work in macOS and newer linux versions
+// https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html#g_t_002dS_002f_002d_002dsplit_002dstring-usage-in-scripts
 
 import "dotenv/config";
 import { resolve } from "path";

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "git submodule sync && git submodule update --init && cd ./src/strategies && npm install",
     "test": "ava --verbose --timeout=20s",
-    "dev": "DEBUG=neume-network-* node ./neume.mjs --path crawl_path.mjs --config config.mjs",
+    "dev": "DEBUG=neume-network-* ./neume.mjs --path crawl_path.mjs --config config.mjs",
     "dev:silent": "node ./src/boot.mjs",
     "prepare": "husky install"
   },


### PR DESCRIPTION
PR #88 was reverted due to a bug which caused the GitHub actions to never stop. This PR fixes that bug by adding a `-S` flag.

Without the `-S` flag, the `--unhandled-rejections` in `#!/usr/bin/env -S node --unhandled-rejections=throw` is not treated as an argument.

This behaviour is not present in macOS but is present in Linux.

After `-S` the behaviour for both the OSes should be similar. Tested it in 11/unhandledRejections branch of neume-network/data. Corresponding run: https://github.com/neume-network/data/actions/runs/3130990388/jobs/5081852773#step:9:1.